### PR TITLE
Use xredis instead of node-redis for ACL support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const redis = require('redis')
+const redis = require('xredis')
 const redisWrapper = require('co-redis')
 
 // Default connection object if config is not provided

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
   },
   "dependencies": {
     "co-redis": "^2.1.1",
-    "redis": "^3.0.2"
+    "xredis": "^1.0.4"
   }
 }


### PR DESCRIPTION
xRedis is derived from node-redis and has ACL support that node-redis doesn't have https://www.npmjs.com/package/xredis